### PR TITLE
Add a Japanese translation.

### DIFF
--- a/src/main/java/javax/servlet/LocalStrings_ja.properties
+++ b/src/main/java/javax/servlet/LocalStrings_ja.properties
@@ -60,5 +60,6 @@
 # Localized for Locale ja_JP
 
 err.not_iso8859_1=ISO 8859-1 \u306e\u6587\u5b57\u3067\u306f\u3042\u308a\u307e\u305b\u3093: {0}
+err.servlet_config_not_initialized=ServletConfig \u306f\u521d\u671f\u5316\u3055\u308c\u3066\u3044\u307e\u305b\u3093
 value.true=true
 value.false=false


### PR DESCRIPTION
err.servlet_config_not_initialized=ServletConfig \u306f\u521d\u671f\u5316\u3055\u308c\u3066\u3044\u307e\u305b\u3093
err.servlet_config_not_initialized=ServletConfig は初期化されていません